### PR TITLE
Allow Symfony 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "psr-4": {"Fervo\\ValidatedMessage\\": "src/"}
     },
     "require": {
-        "symfony/validator": "~2.3",
-        "simple-bus/message-bus": "~2.0"
+        "symfony/validator": "^2.3 || ^3.0",
+        "simple-bus/message-bus": "^2.0"
     }
 }


### PR DESCRIPTION
I have checked the `ConstraintViolationListInterface` and `ValidatorInterface` and there are no BC breaks in those files between 2.3 and 3.0. 
