### PR TITLE
Allow Symfony4 and MessageBus3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "psr-4": {"Fervo\\ValidatedMessage\\": "src/"}
     },
     "require": {
-        "symfony/validator": "^2.3 || ^3.0",
-        "simple-bus/message-bus": "^2.0"
+        "symfony/validator": "^2.3 || ^3.0 || 4.0",
+        "simple-bus/message-bus": "^2.0 || ^3.0"
     }
 }


### PR DESCRIPTION
There are no significant changes in MessageBus between major versions
https://github.com/SimpleBus/MessageBus/compare/v2.2.2...v3.0.0